### PR TITLE
migration ファイルの typo と思われる点を修正しました

### DIFF
--- a/db/migrate/20111018002623_create_executions.rb
+++ b/db/migrate/20111018002623_create_executions.rb
@@ -13,7 +13,7 @@ class CreateExecutions < ActiveRecord::Migration
 
     add_index :impasse_executions, :test_plan_case_id, :name => 'IDX_IMPASSE_EXECUTIONS_01'
     add_index :impasse_executions, :tester_id, :name => 'IDX_IMPASSE_EXECUTIONS_02'
-    add_index :impasse_executions, :excution_ts, :name => 'IDX_IMPASSE_EXECUTIONS_03'
+    add_index :impasse_executions, :execution_ts, :name => 'IDX_IMPASSE_EXECUTIONS_03'
   end
 
   def self.down

--- a/db/migrate/20111018002749_create_execution_bugs.rb
+++ b/db/migrate/20111018002749_create_execution_bugs.rb
@@ -6,7 +6,7 @@ class CreateExecutionBugs < ActiveRecord::Migration
     end
 
     add_index :impasse_execution_bugs, :execution_id, :name => 'IDX_IMPASSE_EXECUTION_BUGS_01'
-    add_index :impasse_execution_bugs, :bug_id, :name => 'IDX_IMPASSE_EXECUTION_BUGS_01'
+    add_index :impasse_execution_bugs, :bug_id, :name => 'IDX_IMPASSE_EXECUTION_BUGS_02'
   end
 
   def self.down


### PR DESCRIPTION
インストールしようとして rake db:migrate:plugin を実行したらエラーになってしまいましたので、修正しました。
