### PR TITLE
labelled_tabular_form_for

### DIFF
--- a/app/views/impasse_custom_fields/edit.html.erb
+++ b/app/views/impasse_custom_fields/edit.html.erb
@@ -3,7 +3,7 @@
   &#187; <%= h @custom_field.name %></h2>
 
 <% if Rails::VERSION::MAJOR < 3 %>
-  <% labelled_tabular_form_for :custom_field, @custom_field, { :action => :edit, :id => @custom_field } do |f| %>
+  <% labelled_form_for :custom_field, @custom_field, { :action => :edit, :id => @custom_field } do |f| %>
     <%= render :partial => "custom_fields/form", :locals => {:f => f} %>
   <%= hidden_field_tag 'type', @custom_field.type %>
     <%= submit_tag l(:button_save) %>

--- a/app/views/impasse_custom_fields/new.html.erb
+++ b/app/views/impasse_custom_fields/new.html.erb
@@ -3,7 +3,7 @@
   &#187; <%= l(:label_custom_field_new) %></h2>
 
 <% if Rails::VERSION::MAJOR < 3 %>
-  <% labelled_tabular_form_for :custom_field, @custom_field, {} do |f| %>
+  <% labelled_form_for :custom_field, @custom_field, {} do |f| %>
     <%= render :partial => "custom_fields/form", :locals => {:f => f} %>
   <%= hidden_field_tag 'type', @custom_field.type %>
     <%= submit_tag l(:button_create) %>

--- a/app/views/impasse_execution_bugs/_new.html.erb
+++ b/app/views/impasse_execution_bugs/_new.html.erb
@@ -1,6 +1,6 @@
 <div class="box">
 <% if Rails::VERSION::MAJOR < 3 %>
-  <% labelled_tabular_form_for :issue, @issue, :url => {:controller => 'issues', :action => 'create', :project_id => @project},
+  <% labelled_form_for :issue, @issue, :url => {:controller => 'issues', :action => 'create', :project_id => @project},
                                :html => {:multipart => true, :id => 'issue-form', :class => 'tabular new-issue-form'} do |f| %>
     <%= error_messages_for 'issue' %>
     <%= render :partial => 'form', :locals => {:f => f} %>

--- a/app/views/impasse_executions/_edit.html.erb
+++ b/app/views/impasse_executions/_edit.html.erb
@@ -1,5 +1,5 @@
 <% if Rails::VERSION::MAJOR < 3 %>
-  <% labelled_tabular_form_for :execution, @execution, {} do |f| %>
+  <% labelled_form_for :execution, @execution, {} do |f| %>
     <%= render :partial => "form", :locals => { :f => f } %>
   <% end %>
 <% else %>

--- a/app/views/impasse_settings/_form.html.erb
+++ b/app/views/impasse_settings/_form.html.erb
@@ -1,3 +1,4 @@
+<% self.class.send(:include, ImpasseSettingsHelper) -%> 
 <%= error_messages_for 'setting' %>
 <div class="box tabular">
   <p><%=f.select :bug_tracker_id, @project.trackers.collect {|t| [t.name, t.id]}, :required => true %></p>

--- a/app/views/impasse_settings/_show.html.erb
+++ b/app/views/impasse_settings/_show.html.erb
@@ -10,7 +10,7 @@
 
 %>
 <% if Rails::VERSION::MAJOR < 3 %>
-  <% labelled_tabular_form_for :setting, @impasse_setting,
+  <% labelled_form_for :setting, @impasse_setting,
      :url => {:controller => :impasse_settings, :action => :edit, :project_id => @project }, 
      :lang => current_language do |f| %>
   <%= render :partial => 'impasse_settings/form', :locals => {:f => f } %>

--- a/app/views/impasse_test_case/_edit.html.erb
+++ b/app/views/impasse_test_case/_edit.html.erb
@@ -1,5 +1,5 @@
 <% if Rails::VERSION::MAJOR < 3 %>
-  <% labelled_tabular_form_for :test_case, @test_case, {} do |f| %>
+  <% labelled_form_for :test_case, @test_case, {} do |f| %>
     <%= render :partial => "form.#{params[:node_type]}", :locals => {:form => f} %>
     <button type="button" class="ui-button-submit"><%=l(:button_update)%></button>
     <button type="button" class="ui-button-cancel"><%=l(:button_cancel)%></button>

--- a/app/views/impasse_test_case/_new.html.erb
+++ b/app/views/impasse_test_case/_new.html.erb
@@ -1,5 +1,5 @@
 <% if Rails::VERSION::MAJOR < 3 %>
-  <% labelled_tabular_form_for :test_case, @test_case, {} do |f| %>
+  <% labelled_form_for :test_case, @test_case, {} do |f| %>
     <%= render :partial => "form.#{params[:node_type]}", :locals => {:form => f} %>
     <button type="button" class="ui-button-submit"><%=l(:button_create)%></button>
     <button type="button" class="ui-button-cancel"><%=l(:button_cancel)%></button>

--- a/app/views/impasse_test_case/index.html.erb
+++ b/app/views/impasse_test_case/index.html.erb
@@ -96,14 +96,14 @@
       <% if @allowed_projects.present? %>
 	<p><%=l(:notice_copy_cases_to_another_project)%></p>
 	<% if Rails::VERSION::MAJOR < 3 %>
-          <% labelled_tabular_form_for :copy_tests, @project, { :action => :copy_to_another_project } do |f| %>
+          <% labelled_form_for :copy_tests, @project, { :action => :copy_to_another_project } do |f| %>
 	    <p>
 	      <label for="dest_project_id"><%= l(:field_project) %></label>
 	      <%= select_tag('dest_project_id', project_tree_options_for_select(@allowed_projects, :selected => @target_project)) %>
 	    </p>
 	  <% end %>
 	<% else %>
-          <% output = labelled_tabular_form_for @project, :as => :copy_tests, :url => { :action => :copy_to_another_project } do |f| %>
+          <% output = labelled_form_for @project, :as => :copy_tests, :url => { :action => :copy_to_another_project } do |f| %>
 	    <p>
 	      <label for="dest_project_id"><%= l(:field_project) %></label>
 	      <%= select_tag('dest_project_id', project_tree_options_for_select(@allowed_projects, :selected => @target_project)) %>

--- a/app/views/impasse_test_plans/copy.html.erb
+++ b/app/views/impasse_test_plans/copy.html.erb
@@ -3,7 +3,7 @@
     link_to(l(:label_test_plans_list), { :controller => :impasse_test_plans, :action => :index, :project_id => @project})
 ]%>
 <% if Rails::VERSION::MAJOR < 3 %>
-  <% labelled_tabular_form_for :test_plan, @test_plan, {} do |f| %>
+  <% labelled_form_for :test_plan, @test_plan, {} do |f| %>
     <%= render :partial => "form", :locals => {:form => f} %>
     <%= submit_tag l(:button_create) %>
   <% end %>

--- a/app/views/impasse_test_plans/edit.html.erb
+++ b/app/views/impasse_test_plans/edit.html.erb
@@ -6,7 +6,7 @@
 
 <%= render_impasse_tabs %>
 <% if Rails::VERSION::MAJOR < 3 %>
-  <% labelled_tabular_form_for :test_plan, @test_plan, {} do |f| %>
+  <% labelled_form_for :test_plan, @test_plan, {} do |f| %>
     <%= render :partial => "form", :locals => {:form => f} %>
     <%= submit_tag l(:button_update) %>
   <% end %>

--- a/app/views/impasse_test_plans/new.html.erb
+++ b/app/views/impasse_test_plans/new.html.erb
@@ -1,5 +1,5 @@
 <% if Rails::VERSION::MAJOR < 3 %>
-  <% labelled_tabular_form_for :test_plan, @test_plan, {} do |f| %>
+  <% labelled_form_for :test_plan, @test_plan, {} do |f| %>
     <%= render :partial => "form", :locals => {:form => f} %>
     <%= submit_tag l(:button_create) %>
   <% end %>


### PR DESCRIPTION
The plugin was not working because the templates still have references to _labelled_tabular_form_for_ and (accordingly to hotfix/1.2.3) they should be _labelled_form_for_.
The plugin is now working.
