### PR TITLE
Fixing route syntax issue wrt Rails 4.x

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,13 +11,13 @@ if Rails::VERSION::MAJOR < 3
     map.connect 'impasse/custom_fields/:action/:id', :controller => :impasse_custom_fields
   end
 else
-  match 'projects/:project_id/impasse/test_case/(:action(/:id))', :controller => 'impasse_test_case'
-  match 'projects/:project_id/impasse/test_plans/(:action(/:id))', :controller => 'impasse_test_plans'
-  match 'projects/:project_id/impasse/executions/(:action(/:id))', :controller => 'impasse_executions'
-  match 'projects/:project_id/impasse/execution_bugs/(:action(/:id))', :controller => 'impasse_execution_bugs'
-  match 'projects/:project_id/impasse/settings/(:action(/:id))', :controller => 'impasse_settings'
-  match 'projects/:project_id/impasse/requirement_issues/(:action(/:id))', :controller => 'impasse_requirement_issues'
-  match 'projects/:project_id/impasse/screenshots/:attachment_id(.:size).:format', :controller => 'impasse_screenshots', :action => 'show', :attachment_id => /\d+/
-  match 'projects/:project_id/impasse/screenshots/(:action/(:id))', :controller => 'impasse_screenshots'
-  match 'impasse/custom_fields/(:action(/:id))', :controller => 'impasse_custom_fields'
+  match 'projects/:project_id/impasse/test_case/(:action(/:id))', :controller => 'impasse_test_case', :via => [:get, :post]
+  match 'projects/:project_id/impasse/test_plans/(:action(/:id))', :controller => 'impasse_test_plans', :via => [:get, :post]
+  match 'projects/:project_id/impasse/executions/(:action(/:id))', :controller => 'impasse_executions', :via => [:get, :post]
+  match 'projects/:project_id/impasse/execution_bugs/(:action(/:id))', :controller => 'impasse_execution_bugs', :via => [:get, :post]
+  match 'projects/:project_id/impasse/settings/(:action(/:id))', :controller => 'impasse_settings', :via => [:get, :post]
+  match 'projects/:project_id/impasse/requirement_issues/(:action(/:id))', :controller => 'impasse_requirement_issues', :via => [:get, :post]
+  match 'projects/:project_id/impasse/screenshots/:attachment_id(.:size).:format', :controller => 'impasse_screenshots', :action => 'show', :attachment_id => /\d+/, :via => [:get, :post]
+  match 'projects/:project_id/impasse/screenshots/(:action/(:id))', :controller => 'impasse_screenshots', :via => [:get, :post]
+  match 'impasse/custom_fields/(:action(/:id))', :controller => 'impasse_custom_fields', :via => [:get, :post]
 end


### PR DESCRIPTION
Quite a basic patch (accepts GET and POST on all routes), but seems semantically equivalent to the original code. Works with Redmine 3.x / Rails 4.x.
